### PR TITLE
Standard Types

### DIFF
--- a/src/OSP.cpp
+++ b/src/OSP.cpp
@@ -117,7 +117,7 @@ SystemOsp::SystemOsp(Context* context) : Object(context)
     category->SetVar("DisplayName", "Debug Parts");
 
     // Make 20 rocket cubes
-    for (uint i = 0; i < 20; i ++)
+    for (int i = 0; i < 20; i ++)
     {
         // Make a new child in the dbg category
         Node* aPart = category->CreateChild("dbg_" + String(i));

--- a/src/PerformanceCurves.cpp
+++ b/src/PerformanceCurves.cpp
@@ -12,7 +12,7 @@ PerformanceCurves::PerformanceCurves(HashMap<StringHash, float> *inputs, float r
 float PerformanceCurves::get_float(float f)
 {
     float value = f;
-    for (uint i = 0; i < m_curves.Size(); i ++)
+    for (int i = 0; i < m_curves.Size(); i ++)
     {
         Curve* curve = &(m_curves[i]);
         // get the number, then scale to array index
@@ -41,7 +41,7 @@ void PerformanceCurves::add_factor(StringHash factor, float range, float minimum
     curve.m_factor = factor;
 
     // Put curve into the array in ascending order
-    for (uint i = 0; i < m_curves.Size(); i ++)
+    for (int i = 0; i < m_curves.Size(); i ++)
     {
         if (m_curves[i].m_factor > factor)
         {
@@ -55,7 +55,7 @@ void PerformanceCurves::add_factor(StringHash factor, float range, float minimum
 
 void PerformanceCurves::set_linear(StringHash factor, uint16_t low, uint16_t high)
 {
-    for (uint i = 0; i < m_curves.Size(); i ++)
+    for (int i = 0; i < m_curves.Size(); i ++)
     {
         if (m_curves[i].m_factor == factor)
         {

--- a/src/PlanetWrenderer.cpp
+++ b/src/PlanetWrenderer.cpp
@@ -255,7 +255,7 @@ void PlanetWrenderer::set_visible(trindex t, bool visible)
         tri->m_index = m_indCount * 3;
 
         // Put data into indBuf
-        uint xz[3];
+        unsigned xz[3];
         xz[0] = tri->m_verts[0];
         xz[1] = tri->m_verts[1];
         xz[2] = tri->m_verts[2];
@@ -284,7 +284,7 @@ void PlanetWrenderer::set_visible(trindex t, bool visible)
 
         // get the index buffer data of the last triangle (last 3 ints), and put it into the new location
 
-        uint* xz = reinterpret_cast<uint*>(m_indBuf->GetShadowData() + (m_indCount * 3 * sizeof(uint)));
+        unsigned* xz = reinterpret_cast<unsigned*>(m_indBuf->GetShadowData() + (m_indCount * 3 * sizeof(unsigned)));
         //printf("Hiding: %u, %u, %u\n", xz[0], xz[1], xz[2]);
         m_indBuf->SetDataRange(xz, tri->m_index, 3);
         //this.indexBuffer.set(this.indexBuffer.slice(this.indexCount * 3, this.indexCount * 3 + 3), tri.index);
@@ -308,7 +308,7 @@ void PlanetWrenderer::subdivide(trindex t)
 
     // Add the 4 new triangles
     // Top Left Right Center
-    uint freeSize = m_trianglesFree.Size();
+    unsigned freeSize = m_trianglesFree.Size();
     if (freeSize == 0) {
         tri->m_children = m_triangles.Size();
         m_triangles.Resize(tri->m_children + 4);
@@ -464,7 +464,7 @@ void PlanetWrenderer::find_refs(SubTriangle& tri)
 
     for (int i = 0; i < 3; i ++)
     {
-        uint whateven = m_trianglesFree.IndexOf(int(tri.m_neighbors[i] / 4) * 4);
+        unsigned whateven = m_trianglesFree.IndexOf(int(tri.m_neighbors[i] / 4) * 4);
         if (whateven != m_trianglesFree.Size() )
         {
             printf("Deleted triangle %u referenced on side: %u\n", m_trianglesFree[whateven], i);
@@ -476,7 +476,7 @@ void PlanetWrenderer::find_refs(SubTriangle& tri)
 
         for (int i = 0; i < 4; i ++)
         {
-            uint whateven = m_trianglesFree.IndexOf(tri.m_children + i);
+            unsigned whateven = m_trianglesFree.IndexOf(tri.m_children + i);
             if (whateven != m_trianglesFree.Size() )
             {
                 printf("Deleted triangle %u referenced on child: %u\n", m_trianglesFree[whateven], i);

--- a/src/PlanetWrenderer.h
+++ b/src/PlanetWrenderer.h
@@ -109,8 +109,6 @@ class PlanetWrenderer
 
 public:
 
-    ushort birb_ = 4;
-
     PlanetWrenderer();
     ~PlanetWrenderer();
     bool is_ready() {return m_ready;}


### PR DESCRIPTION
Changes loops to use int instead of uint - this is generally just good for optimisations, and has less maths pitfalls in many cases (such as calculating differences etc, which are negative values).

Changes uint elsewhere to unsigned, as uint is a GCC-specific type.

Removes unused _birb member.